### PR TITLE
Show mobile menu in front of handheld bar

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,11 +1,18 @@
+@charset "UTF-8";
 .storefront-hamburger-menu-active .shm-close {
-  display: none; }
+  display: none;
+}
 
 @media screen and (max-width: 767px) {
+  .site-header {
+    z-index: 10000;
+  }
+
   .storefront-hamburger-menu-active .main-navigation ul li a {
-    padding: .857em 1.387em; }
+    padding: 0.857em 1.387em;
+  }
   .storefront-hamburger-menu-active .main-navigation .handheld-navigation,
-  .storefront-hamburger-menu-active .main-navigation div.menu {
+.storefront-hamburger-menu-active .main-navigation div.menu {
     position: fixed;
     top: 0;
     left: -80%;
@@ -21,46 +28,59 @@
     transition: left 0.2s;
     z-index: 9999;
     display: block !important;
-    border-right: 1px solid rgba(255, 255, 255, 0.2); }
-    .storefront-hamburger-menu-active .main-navigation .handheld-navigation > ul,
-    .storefront-hamburger-menu-active .main-navigation div.menu > ul {
-      margin-top: .53em; }
+    border-right: 1px solid rgba(255, 255, 255, 0.2);
+  }
+  .storefront-hamburger-menu-active .main-navigation .handheld-navigation > ul,
+.storefront-hamburger-menu-active .main-navigation div.menu > ul {
+    margin-top: 0.53em;
+  }
   .storefront-hamburger-menu-active .main-navigation.toggled button.menu-toggle:before {
-    transform: translateY(-4px); }
+    transform: translateY(-4px);
+  }
   .storefront-hamburger-menu-active .main-navigation.toggled button.menu-toggle:after {
-    transform: translateY(4px); }
+    transform: translateY(4px);
+  }
   .storefront-hamburger-menu-active .main-navigation.toggled button.menu-toggle span:before {
-    opacity: 1; }
+    opacity: 1;
+  }
   .storefront-hamburger-menu-active .main-navigation.toggled .handheld-navigation,
-  .storefront-hamburger-menu-active .main-navigation.toggled div.menu {
+.storefront-hamburger-menu-active .main-navigation.toggled div.menu {
     left: 0;
-    box-shadow: 0 0 2em rgba(0, 0, 0, 0.7); }
+    box-shadow: 0 0 2em rgba(0, 0, 0, 0.7);
+  }
   .storefront-hamburger-menu-active .shm-close {
     display: block;
     background-color: rgba(0, 0, 0, 0.5);
     cursor: pointer;
     overflow: hidden;
     font-weight: bold;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.2); }
-    .storefront-hamburger-menu-active .shm-close:before {
-      font-family: "FontAwesome";
-      font-weight: 400;
-      content: '\f00d';
-      margin-right: 1em;
-      display: inline-block;
-      padding: .857em 0 .857em 1.387em; }
+    border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  }
+  .storefront-hamburger-menu-active .shm-close:before {
+    font-family: "FontAwesome";
+    font-weight: 400;
+    content: "";
+    margin-right: 1em;
+    display: inline-block;
+    padding: 0.857em 0 0.857em 1.387em;
+  }
   .storefront-hamburger-menu-active .site-header-cart .cart-contents {
-    right: 2.618em; }
+    right: 2.618em;
+  }
   .storefront-hamburger-menu-active.admin-bar .main-navigation .handheld-navigation,
-  .storefront-hamburger-menu-active.admin-bar .main-navigation div.menu {
-    padding-top: 32px; } }
-
+.storefront-hamburger-menu-active.admin-bar .main-navigation div.menu {
+    padding-top: 32px;
+  }
+}
 .storefront-2-3.storefront-hamburger-menu-active .main-navigation .shm-close:before {
   font-family: "Font Awesome 5 Free";
   font-weight: 900;
-  content: "\f00d"; }
+  content: "";
+}
 
 @media screen and (max-width: 782px) {
   .storefront-hamburger-menu-active.admin-bar .main-navigation .handheld-navigation,
-  .storefront-hamburger-menu-active.admin-bar .main-navigation div.menu {
-    padding-top: 46px; } }
+.storefront-hamburger-menu-active.admin-bar .main-navigation div.menu {
+    padding-top: 46px;
+  }
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -9,6 +9,9 @@
 }
 
 @media screen and (max-width: 767px) {
+		.site-header {
+			z-index: 10000;
+		}
 	 .storefront-hamburger-menu-active {
 		.main-navigation {
 			ul {


### PR DESCRIPTION
Fixes #18

### Screenshots

<table>
<tr>
<td>Before:
<br><br>

![#18-before](https://user-images.githubusercontent.com/3323310/100337001-6eff5c00-3009-11eb-8904-c44f7561223c.png)
</td>
<td>After:
<br><br>

![#18-after](https://user-images.githubusercontent.com/3323310/100336997-6d359880-3009-11eb-887a-589e23554dd4.png)
</td>
</tr>
</table>

### How to test the changes in this Pull Request:

1. Install and activate the [Storefront theme](https://woocommerce.com/storefront/)
2. Install and activate the [Storefront Hamburger Menu extension](https://woocommerce.com/products/storefront-hamburger-menu/)
3. Create an extra long handheld menu, e.g. by adding all demo products as menu items
4. Look up site on a mobile device

### Changelog

> Fix: The handheld menu will no longer disappear behing behind the handheld footer bar

### Tests

- [ ] I've tested [browser support](https://make.wordpress.org/core/handbook/best-practices/browser-support/) to ensure compatibility with >= IE11
- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
