### PR TITLE
Fix long menu when hidden by footer bar

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -25,7 +25,7 @@
 				top: 0;
 				left: -80%;
 				width: 80%;
-				height: 100%;
+				height: calc(100vh - 69px);
 				transition: left 0.2s;
 				overflow-y: scroll;
 				-webkit-overflow-scrolling: touch;


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #18 

<!-- Describing the changes made in this Pull Request, and the reason for such changes. -->
When the hamburger menu has numerous items it's hidden by the footer bar. 

As described at https://www.w3schools.com/cssref/pr_pos_overflow.asp, the overflow property only works for block elements with a specified height.

Then, we set the SHM height considering the viewport height less footer bar height, avoiding hide footer bar and allowing scrolling on SHM.

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and doesn't break any other features :) -->

1. Install and activate Woocommerce plugin, Storefront Hamburger Menu plugin, and Storefront theme;
2. Add many options to the menu;
2. Open a browser window on a mobile device;
3. Open the hamburger menu and scroll by the menu.

### Changelog

> Fix long menu when hidden by footer bar

### Tests

- [x] I've tested [browser support](https://make.wordpress.org/core/handbook/best-practices/browser-support/) to ensure compatibility with >= IE11
Chrome on Samsung Galaxy S6 v5.0
Chrome on Samsung Galaxy S7 v6.0
Chrome on Samsung Galaxy S9 v8.0
Safari on iPhone 7 v10.3
Safari on iPhone 8 v12.1 
Safari on iPhone 8 v13.5
Chrome on Xiaomi Redmi Note 7 v9.0
Chrome on Xiaomi Redmi Note 8 v9.0

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
